### PR TITLE
Don't highlight uranium/lava tabs when not selected

### DIFF
--- a/notification.js
+++ b/notification.js
@@ -16,10 +16,10 @@ function activeResourceTab(tab){
 	if(document.getElementById("energyNav").className != "sideTab hidden"){
 		document.getElementById("energyNav").className = "sideTab";
 	}
-	if(document.getElementById("uraniumNav").className === "sideTab info"){
+	if(document.getElementById("uraniumNav").className != "sideTab hidden"){
 		document.getElementById("uraniumNav").className = "sideTab";
 	}
-	if(document.getElementById("lavaNav").className === "sideTab info"){
+	if(document.getElementById("lavaNav").className != "sideTab hidden"){
 		document.getElementById("lavaNav").className = "sideTab";
 	}
 	for(var i = 0; i < resources.length; i++){


### PR DESCRIPTION
Hello! I noticed that the uranium and lava tabs wouldn't un-highlight when I was playing this. ( http://imgur.com/a/KsUX7 ) The `info` class got added repeatedly. I think I've fixed this properly, sorry if I didn't though.